### PR TITLE
Пример внешней обработки исключений при итерировании по коллекции

### DIFF
--- a/HandleEnumerationApp/HandleEnumerationApp.csproj
+++ b/HandleEnumerationApp/HandleEnumerationApp.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/HandleEnumerationApp/HandleEnumerationApp.csproj
+++ b/HandleEnumerationApp/HandleEnumerationApp.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>

--- a/HandleEnumerationApp/Program.cs
+++ b/HandleEnumerationApp/Program.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace HandleEnumerationApp
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            string[] lines = { "1", "a", "b", "2", "3" };
+
+            var loader = new LinqNumbersLoader();
+            IEnumerable<int> numbers = loader.ParseNumbers(lines).HandleEnumerable(ParseLineHandler);
+            foreach (int number in numbers)
+            {
+                Console.WriteLine(number);
+            }
+        }
+
+        private static bool ParseLineHandler(Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(ex.Message);
+            Console.ResetColor();
+
+            return true;
+        }
+    }
+
+    internal interface INumbersLoader
+    {
+        IEnumerable<int> ParseNumbers(IEnumerable<string> lines);
+    }
+
+    internal class YieldReturnNumbersLoader : INumbersLoader
+    {
+        public IEnumerable<int> ParseNumbers(IEnumerable<string> lines)
+        {
+            foreach (string line in lines)
+                yield return int.Parse(line);
+        }
+    }
+
+    internal class LinqNumbersLoader
+    {
+        public IEnumerable<int> ParseNumbers(IEnumerable<string> lines) => lines.Select(int.Parse);
+    }
+
+    public static class EnumerableExtension
+    {
+        public static IEnumerable<T> HandleEnumerable<T>(this IEnumerable<T> enumerable, Func<Exception, bool> handleFunc) =>
+            new EnumerableHandler<T>(enumerable, handleFunc);
+    }
+
+    public class EnumerableHandler<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _enumerable;
+        private readonly Func<Exception, bool> _handleFunc;
+
+        public EnumerableHandler(IEnumerable<T> enumerable, Func<Exception, bool> handleFunc)
+        {
+            _enumerable = enumerable;
+            _handleFunc = handleFunc;
+        }
+
+        public IEnumerator<T> GetEnumerator() => new EnumeratorHandler<T>(_enumerable.GetEnumerator(), _handleFunc);
+
+        IEnumerator IEnumerable.GetEnumerator() => new EnumeratorHandler<T>(_enumerable.GetEnumerator(), _handleFunc);
+    }
+
+    public class EnumeratorHandler<T> : IEnumerator<T>
+    {
+        private readonly IEnumerator<T> _innerEnumerator;
+        private readonly Func<Exception, bool> _handleFunc;
+
+        public EnumeratorHandler(IEnumerator<T> innerEnumerator, Func<Exception, bool> handleFunc)
+        {
+            _innerEnumerator = innerEnumerator;
+            _handleFunc = handleFunc;
+        }
+
+        public bool MoveNext()
+        {
+            try
+            {
+                return _innerEnumerator.MoveNext();
+            }
+            catch (Exception ex)
+            {
+                if (!_handleFunc(ex))
+                    throw;
+
+                MoveNext();
+                return true;
+            }
+        }
+
+        public void Reset() => _innerEnumerator.Reset();
+
+        public T Current => _innerEnumerator.Current;
+
+        object IEnumerator.Current => ((IEnumerator)_innerEnumerator).Current;
+
+        public void Dispose() => _innerEnumerator.Dispose();
+    }
+}

--- a/HandleEnumerationApp/Program.cs
+++ b/HandleEnumerationApp/Program.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 
 namespace HandleEnumerationApp
@@ -51,8 +53,14 @@ namespace HandleEnumerationApp
 
     public static class EnumerableExtension
     {
-        public static IEnumerable<T> HandleEnumerable<T>(this IEnumerable<T> enumerable, Func<Exception, bool> handleFunc) =>
-            new EnumerableHandler<T>(enumerable, handleFunc);
+        public static IEnumerable<T> HandleEnumerable<T>(this IEnumerable<T> enumerable, Func<Exception, bool> handleFunc)
+        {
+            IEnumerable<CustomAttributeData> attributes = enumerable.GetType().CustomAttributes;
+            if (attributes.Any(x => x.AttributeType == typeof(CompilerGeneratedAttribute)))
+                throw new ArgumentException("Yield return enumeration does not support.", nameof(enumerable));
+
+            return new EnumerableHandler<T>(enumerable, handleFunc);
+        }
     }
 
     public class EnumerableHandler<T> : IEnumerable<T>

--- a/Iterators.sln
+++ b/Iterators.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IteratorsApp", "IteratorsAp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckArraysPerformanceApp", "CheckArraysPerformanceApp\CheckArraysPerformanceApp.csproj", "{588BA09C-6DE9-45F9-BDC6-62D4216F5858}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HandleEnumerationApp", "HandleEnumerationApp\HandleEnumerationApp.csproj", "{7F79A3B8-8EBC-4300-91B8-F694D6D935FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{588BA09C-6DE9-45F9-BDC6-62D4216F5858}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{588BA09C-6DE9-45F9-BDC6-62D4216F5858}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{588BA09C-6DE9-45F9-BDC6-62D4216F5858}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F79A3B8-8EBC-4300-91B8-F694D6D935FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F79A3B8-8EBC-4300-91B8-F694D6D935FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F79A3B8-8EBC-4300-91B8-F694D6D935FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F79A3B8-8EBC-4300-91B8-F694D6D935FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Зачастую при создании библиотек по работе с коллекциями требуется обрабатывать отдельные элементы во внешнем коде, при этом необходимо обеспечить дальшнейшее итерирование по исходным данным, а не прерывать процесс. Одним из решений является подписка на событие, которое будет возводиться при исключении и обрабатываться внешним кодом. Тем не менее такой подход весьма громоздкий и требует существенной обвязки, особенно если итерирование идет на одном из нижних уровней и пробрасывается несколько раз через высокоуровневые фасады.

В данном примере я предлагаю использовать отложенное чтение коллеций через LINQ, оборачивая полученный итератор в простой декоратор, которому дополнительно передается обработчик исключений.

К сожалению данный способ не подходит для перечислений, формируемых через `yield return`, по причине прерывания итераций во время исключения. Поэтому не придумал ничего лучше, чем выбрасывать исключение при попытке обернуть такое перечисление 😒 